### PR TITLE
Add Wi-Fi Direct mesh bridge

### DIFF
--- a/bitchat/Models/BitchatPacket.swift
+++ b/bitchat/Models/BitchatPacket.swift
@@ -88,4 +88,11 @@ struct BitchatPacket: Codable {
     static func from(_ data: Data) -> BitchatPacket? {
         BinaryProtocol.decode(data)
     }
+
+    /// Stable identifier used for deduplication across heterogeneous transports.
+    var dedupIdentifier: String {
+        let sender = senderID.hexEncodedString()
+        let digestPrefix = payload.sha256Hash().prefix(4).hexEncodedString()
+        return "\(sender)-\(timestamp)-\(type)-\(digestPrefix)"
+    }
 }

--- a/bitchat/Services/BLEService.swift
+++ b/bitchat/Services/BLEService.swift
@@ -422,6 +422,11 @@ final class BLEService: NSObject {
         let fingerprint = noiseService.getIdentityFingerprint()
         myPeerID = String(fingerprint.prefix(16))
         myPeerIDData = Data(hexString: myPeerID) ?? Data()
+        NotificationCenter.default.post(
+            name: .meshServiceIdentityUpdated,
+            object: self,
+            userInfo: ["peerID": myPeerID]
+        )
     }
 
     private func restartGossipManager() {
@@ -1091,11 +1096,25 @@ final class BLEService: NSObject {
             SecureLogger.error("❌ Failed to convert packet to binary data", category: .session)
             return
         }
+        notifyExternalTransports(packet: packet, data: data)
         if packet.type == MessageType.noiseEncrypted.rawValue {
             sendEncrypted(packet, data: data, pad: padForBLE)
             return
         }
         sendGenericBroadcast(packet, data: data, pad: padForBLE)
+    }
+
+    private func notifyExternalTransports(packet: BitchatPacket, data: Data) {
+        let messageID = makeMessageID(for: packet)
+        NotificationCenter.default.post(
+            name: .meshServiceDidBroadcastPacket,
+            object: self,
+            userInfo: [
+                MeshNotificationUserInfo.packet.rawValue: packet,
+                MeshNotificationUserInfo.data.rawValue: data,
+                MeshNotificationUserInfo.messageID.rawValue: messageID
+            ]
+        )
     }
 
     // MARK: - Broadcast helpers (single responsibility)
@@ -1276,7 +1295,28 @@ final class BLEService: NSObject {
     // Directed send helper (unicast to a specific peerID) without altering packet contents
     private func sendPacketDirected(_ packet: BitchatPacket, to peerID: String) {
         guard let data = packet.toBinaryData(padding: false) else { return }
+        notifyExternalTransports(packet: packet, data: data)
         sendOnAllLinks(packet: packet, data: data, pad: false, directedOnlyPeer: peerID)
+    }
+
+    func ingestExternalPacketData(_ data: Data, fromPeerID neighbor: String? = nil) {
+        guard let packet = BinaryProtocol.decode(data) else {
+            SecureLogger.warning("⚠️ Ignored malformed external packet from auxiliary transport", category: .session)
+            return
+        }
+        ingestExternalPacket(packet, fromPeerID: neighbor)
+    }
+
+    func ingestExternalPacket(_ packet: BitchatPacket, fromPeerID neighbor: String? = nil) {
+        let directPeerID = neighbor ?? packet.senderID.hexEncodedString()
+        let deliver: () -> Void = { [weak self] in
+            self?.handleReceivedPacket(packet, from: directPeerID)
+        }
+        if DispatchQueue.getSpecific(key: messageQueueKey) != nil {
+            deliver()
+        } else {
+            messageQueue.async(execute: deliver)
+        }
     }
 
     // MARK: - Directed store-and-forward

--- a/bitchat/Services/MeshNotifications.swift
+++ b/bitchat/Services/MeshNotifications.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Notification payload keys used for cross-transport mesh coordination.
+enum MeshNotificationUserInfo: String {
+    case packet
+    case data
+    case messageID
+}
+
+extension Notification.Name {
+    /// Posted whenever the mesh transport refreshes its local peer identity.
+    static let meshServiceIdentityUpdated = Notification.Name("chat.bitchat.mesh.identityUpdated")
+
+    /// Posted for every packet that leaves the local mesh transport.
+    static let meshServiceDidBroadcastPacket = Notification.Name("chat.bitchat.mesh.didBroadcastPacket")
+}

--- a/bitchat/Services/WiFiDirectMeshBridge.swift
+++ b/bitchat/Services/WiFiDirectMeshBridge.swift
@@ -1,0 +1,301 @@
+#if os(iOS)
+import Foundation
+import MultipeerConnectivity
+import BitLogger
+
+/// Bridges BitChat's BLE mesh packets over Multipeer Connectivity (Wi-Fi Direct).
+///
+/// The bridge listens for outbound packets from the primary mesh service and
+/// relays them over peer-to-peer Wi-Fi. Incoming Wi-Fi frames are decoded back
+/// into `BitchatPacket`s and injected into the BLE pipeline so the rest of the
+/// application remains unaware of the transport swap.
+final class WiFiDirectMeshBridge: NSObject {
+    private weak var meshService: BLEService?
+    private let workerQueue = DispatchQueue(label: "chat.bitchat.wifidirect")
+    private let serviceType = "bchatmesh"
+
+    private var session: MCSession?
+    private var advertiser: MCNearbyServiceAdvertiser?
+    private var browser: MCNearbyServiceBrowser?
+    private var localPeerID: MCPeerID?
+    private var isRunning = false
+
+    // Track discovered peer BitChat IDs per Multipeer peer
+    private var peerMeshIDs: [MCPeerID: String] = [:]
+
+    // messageID -> (sources, lastSeen)
+    private var inboundSources: [String: Set<String>] = [:]
+    private var inboundTimestamps: [String: Date] = [:]
+    private let inboundRetention: TimeInterval = 30
+
+    init(meshService: BLEService) {
+        self.meshService = meshService
+        super.init()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleIdentityUpdate(_:)),
+            name: .meshServiceIdentityUpdated,
+            object: meshService
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handlePacketBroadcast(_:)),
+            name: .meshServiceDidBroadcastPacket,
+            object: meshService
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        stop()
+    }
+
+    func start() {
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            guard !self.isRunning else { return }
+            self.isRunning = true
+            setupSessionLocked()
+        }
+    }
+
+    func stop() {
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            self.isRunning = false
+            teardownLocked()
+        }
+    }
+
+    @objc private func handleIdentityUpdate(_ notification: Notification) {
+        workerQueue.async { [weak self] in
+            guard let self, self.isRunning else { return }
+            self.restartSessionLocked()
+        }
+    }
+
+    @objc private func handlePacketBroadcast(_ notification: Notification) {
+        guard
+            let packet = notification.userInfo?[MeshNotificationUserInfo.packet.rawValue] as? BitchatPacket,
+            let data = notification.userInfo?[MeshNotificationUserInfo.data.rawValue] as? Data
+        else { return }
+
+        workerQueue.async { [weak self] in
+            self?.relay(packet: packet, data: data)
+        }
+    }
+
+    private func relay(packet: BitchatPacket, data: Data) {
+        pruneInboundCacheLocked()
+        guard let session = session, !session.connectedPeers.isEmpty else { return }
+        guard let meshService = meshService else { return }
+
+        let localPeerIDString = meshService.myPeerID
+        guard !localPeerIDString.isEmpty else { return }
+
+        let messageID = packet.dedupIdentifier
+        let envelopeData: Data
+        do {
+            envelopeData = try Self.encodeEnvelope(peerID: localPeerIDString, payload: data)
+        } catch {
+            SecureLogger.error("WiFiDirectMeshBridge failed to encode envelope: \(error)", category: .session)
+            return
+        }
+
+        let disallowedSources = inboundSources[messageID] ?? []
+        let targets = session.connectedPeers.filter { peer in
+            guard let remoteID = self.peerMeshIDs[peer] else { return true }
+            return !disallowedSources.contains(remoteID)
+        }
+
+        guard !targets.isEmpty else { return }
+
+        do {
+            try session.send(envelopeData, toPeers: targets, with: .reliable)
+        } catch {
+            SecureLogger.warning("WiFiDirectMeshBridge send failed: \(error.localizedDescription)", category: .session)
+        }
+    }
+
+    private func setupSessionLocked() {
+        teardownLocked()
+        guard let meshService = meshService else { return }
+        let peerIDString = meshService.myPeerID
+        guard !peerIDString.isEmpty else { return }
+
+        let displayPrefix = String(peerIDString.prefix(15))
+        let local = MCPeerID(displayName: "mesh-\(displayPrefix)")
+        localPeerID = local
+
+        let session = MCSession(peer: local, securityIdentity: nil, encryptionPreference: .required)
+        session.delegate = self
+        self.session = session
+
+        let advertiser = MCNearbyServiceAdvertiser(
+            peer: local,
+            discoveryInfo: ["peerID": peerIDString],
+            serviceType: serviceType
+        )
+        advertiser.delegate = self
+        advertiser.startAdvertisingPeer()
+        self.advertiser = advertiser
+
+        let browser = MCNearbyServiceBrowser(peer: local, serviceType: serviceType)
+        browser.delegate = self
+        browser.startBrowsingForPeers()
+        self.browser = browser
+    }
+
+    private func restartSessionLocked() {
+        teardownLocked()
+        if isRunning {
+            setupSessionLocked()
+        }
+    }
+
+    private func teardownLocked() {
+        advertiser?.stopAdvertisingPeer()
+        browser?.stopBrowsingForPeers()
+        advertiser = nil
+        browser = nil
+        session?.disconnect()
+        session = nil
+        peerMeshIDs.removeAll()
+        inboundSources.removeAll()
+        inboundTimestamps.removeAll()
+    }
+
+    private func pruneInboundCacheLocked(now: Date = Date()) {
+        for (messageID, timestamp) in inboundTimestamps {
+            if now.timeIntervalSince(timestamp) > inboundRetention {
+                inboundTimestamps.removeValue(forKey: messageID)
+                inboundSources.removeValue(forKey: messageID)
+            }
+        }
+    }
+
+    private func recordInbound(messageID: String, sourcePeerID: String) {
+        pruneInboundCacheLocked()
+        if inboundSources[messageID] != nil {
+            inboundSources[messageID]?.insert(sourcePeerID)
+        } else {
+            inboundSources[messageID] = [sourcePeerID]
+        }
+        inboundTimestamps[messageID] = Date()
+    }
+
+    private static func encodeEnvelope(peerID: String, payload: Data) throws -> Data {
+        guard let peerIDData = peerID.data(using: .utf8), peerIDData.count <= 255 else {
+            throw NSError(domain: "chat.bitchat.wifi", code: 1, userInfo: [NSLocalizedDescriptionKey: "peerID too long"])
+        }
+        var data = Data()
+        data.append(1) // version
+        data.append(UInt8(peerIDData.count))
+        data.append(peerIDData)
+        data.append(payload)
+        return data
+    }
+
+    private static func decodeEnvelope(_ data: Data) throws -> (peerID: String, payload: Data) {
+        guard data.count >= 2 else {
+            throw NSError(domain: "chat.bitchat.wifi", code: 2, userInfo: [NSLocalizedDescriptionKey: "envelope too short"])
+        }
+        var idx = data.startIndex
+        let version = data[idx]
+        guard version == 1 else {
+            throw NSError(domain: "chat.bitchat.wifi", code: 3, userInfo: [NSLocalizedDescriptionKey: "unsupported version \(version)"])
+        }
+        idx = data.index(after: idx)
+        let length = Int(data[idx])
+        idx = data.index(after: idx)
+        guard data.count >= idx + length else {
+            throw NSError(domain: "chat.bitchat.wifi", code: 4, userInfo: [NSLocalizedDescriptionKey: "invalid envelope length"])
+        }
+        let peerIDData = data[idx..<idx+length]
+        idx += length
+        guard let peerID = String(data: peerIDData, encoding: .utf8) else {
+            throw NSError(domain: "chat.bitchat.wifi", code: 5, userInfo: [NSLocalizedDescriptionKey: "invalid peerID encoding"])
+        }
+        let payload = data[idx...]
+        return (peerID, Data(payload))
+    }
+}
+
+extension WiFiDirectMeshBridge: MCSessionDelegate {
+    func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            if state == .notConnected {
+                self.peerMeshIDs.removeValue(forKey: peerID)
+            }
+        }
+    }
+
+    func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
+        workerQueue.async { [weak self] in
+            guard let self, let meshService = self.meshService else { return }
+            do {
+                let envelope = try Self.decodeEnvelope(data)
+                self.peerMeshIDs[peerID] = envelope.peerID
+                guard let packet = BitchatPacket.from(envelope.payload) else { return }
+                let messageID = packet.dedupIdentifier
+                self.recordInbound(messageID: messageID, sourcePeerID: envelope.peerID)
+                meshService.ingestExternalPacket(packet, fromPeerID: envelope.peerID)
+            } catch {
+                SecureLogger.warning("WiFiDirectMeshBridge received invalid payload: \(error.localizedDescription)", category: .session)
+            }
+        }
+    }
+
+    func session(_ session: MCSession, didReceive stream: InputStream, withName streamName: String, fromPeer peerID: MCPeerID) {
+        stream.close()
+    }
+
+    func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, with progress: Progress) {}
+
+    func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, at localURL: URL?, withError error: Error?) {}
+
+    func session(_ session: MCSession, didReceive certificate: [Any]?, fromPeer peerID: MCPeerID, certificateHandler: @escaping (Bool) -> Void) {
+        certificateHandler(true)
+    }
+}
+
+extension WiFiDirectMeshBridge: MCNearbyServiceAdvertiserDelegate {
+    func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
+        workerQueue.async { [weak self] in
+            guard let self, let session = self.session else {
+                invitationHandler(false, nil)
+                return
+            }
+            invitationHandler(true, session)
+        }
+    }
+
+    func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didNotStartAdvertisingPeer error: Error) {
+        SecureLogger.error("WiFiDirectMeshBridge advertiser failed: \(error.localizedDescription)", category: .session)
+    }
+}
+
+extension WiFiDirectMeshBridge: MCNearbyServiceBrowserDelegate {
+    func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String : String]?) {
+        workerQueue.async { [weak self] in
+            guard let self, let session = self.session else { return }
+            browser.invitePeer(peerID, to: session, withContext: nil, timeout: 10)
+            if let meshID = info?["peerID"] {
+                self.peerMeshIDs[peerID] = meshID
+            }
+        }
+    }
+
+    func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
+        workerQueue.async { [weak self] in
+            self?.peerMeshIDs.removeValue(forKey: peerID)
+        }
+    }
+
+    func browser(_ browser: MCNearbyServiceBrowser, didNotStartBrowsingForPeers error: Error) {
+        SecureLogger.error("WiFiDirectMeshBridge browser failed: \(error.localizedDescription)", category: .session)
+    }
+}
+#endif

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -345,6 +345,9 @@ final class ChatViewModel: ObservableObject, BitchatDelegate {
     // MARK: - Services and Storage
     
     let meshService: Transport
+#if os(iOS)
+    private var wifiDirectBridge: WiFiDirectMeshBridge?
+#endif
     let identityManager: SecureIdentityStateManagerProtocol
     
     private var nostrRelayManager: NostrRelayManager?
@@ -497,7 +500,12 @@ final class ChatViewModel: ObservableObject, BitchatDelegate {
         self.keychain = keychain
         self.identityManager = identityManager
         self.meshService = BLEService(keychain: keychain, identityManager: identityManager)
-        
+#if os(iOS)
+        if let bleTransport = self.meshService as? BLEService {
+            self.wifiDirectBridge = WiFiDirectMeshBridge(meshService: bleTransport)
+        }
+#endif
+
         // Load persisted read receipts
         if let data = UserDefaults.standard.data(forKey: "sentReadReceipts"),
            let receipts = try? JSONDecoder().decode([String].self, from: data) {
@@ -545,10 +553,13 @@ final class ChatViewModel: ObservableObject, BitchatDelegate {
         
         // Set nickname before starting services
         meshService.setNickname(nickname)
-        
+
         // Start mesh service immediately
         meshService.startServices()
-        
+#if os(iOS)
+        wifiDirectBridge?.start()
+#endif
+
         // Announce Tor status (geohash-only; do not show in mesh chat). Only when auto-start is allowed.
         if TorManager.shared.torEnforced && !torStatusAnnounced && TorManager.shared.isAutoStartAllowed() {
             torStatusAnnounced = true
@@ -3006,7 +3017,10 @@ final class ChatViewModel: ObservableObject, BitchatDelegate {
     @objc func applicationWillTerminate() {
         // Send leave message to all peers
         meshService.stopServices()
-        
+#if os(iOS)
+        wifiDirectBridge?.stop()
+#endif
+
         // Force save any pending identity changes (verifications, favorites, etc)
         identityManager.forceSave()
         


### PR DESCRIPTION
## Summary
- add mesh notification helpers and a reusable dedup identifier for packets
- expose auxiliary packet ingestion on the BLE transport and emit outbound notifications
- add an iOS Wi-Fi Direct bridge that relays packets via Multipeer Connectivity and wire it into the chat view model

## Testing
- Not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc0e7f2bd883329a1f628e81e30e30