### PR TITLE
Add Wi-Fi Direct resource sharing and donor mode controller

### DIFF
--- a/bitchat/Services/MeshNotifications.swift
+++ b/bitchat/Services/MeshNotifications.swift
@@ -13,4 +13,7 @@ extension Notification.Name {
 
     /// Posted for every packet that leaves the local mesh transport.
     static let meshServiceDidBroadcastPacket = Notification.Name("chat.bitchat.mesh.didBroadcastPacket")
+
+    /// Posted whenever Wi-Fi Direct donor mode updates its lifecycle state.
+    static let wifiDirectDonorStateChanged = Notification.Name("chat.bitchat.wifidirect.donorStateChanged")
 }

--- a/bitchat/Services/WiFiDirectDonorModeController.swift
+++ b/bitchat/Services/WiFiDirectDonorModeController.swift
@@ -1,0 +1,157 @@
+#if os(iOS)
+import Foundation
+import NetworkExtension
+
+/// Coordinates "Donor Mode" – a convenience wrapper around NetworkExtension APIs that
+/// allows a Wi‑Fi Direct peer to proxy internet connectivity for nearby nodes.
+///
+/// The class does not ship an embedded Packet Tunnel provider; instead it configures
+/// an external provider (declared in the host app's extensions) and exposes a simple
+/// lifecycle interface for the rest of the app.
+@available(iOS 15.0, *)
+final class WiFiDirectDonorModeController {
+    struct Configuration: Equatable {
+        /// The bundle identifier of the `NEPacketTunnelProvider` extension that
+        /// performs actual packet forwarding. This must be declared in the host app.
+        let providerBundleIdentifier: String
+        /// Optional metadata propagated to the provider during startup.
+        let options: [String: NSObject]
+
+        init(providerBundleIdentifier: String, options: [String: NSObject] = [:]) {
+            self.providerBundleIdentifier = providerBundleIdentifier
+            self.options = options
+        }
+    }
+
+    enum State: Equatable {
+        case idle
+        case preparing
+        case active
+        case stopping
+        case failed(String)
+    }
+
+    private let queue = DispatchQueue(label: "chat.bitchat.wifidirect.donor")
+    private var manager: NETunnelProviderManager?
+
+    private(set) var state: State = .idle {
+        didSet {
+            if oldValue != state {
+                notifyStateChanged()
+            }
+        }
+    }
+
+    func enable(with configuration: Configuration, completion: @escaping (Result<Void, Error>) -> Void) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            guard case .idle = self.state else {
+                completion(.failure(NSError(domain: "chat.bitchat.donor", code: 1, userInfo: [NSLocalizedDescriptionKey: "Donor mode already active"])) )
+                return
+            }
+
+            self.state = .preparing
+            NETunnelProviderManager.loadAllFromPreferences { managers, error in
+                if let error {
+                    self.queue.async {
+                        self.state = .failed(error.localizedDescription)
+                        completion(.failure(error))
+                    }
+                    return
+                }
+
+                let manager = managers?.first(where: { ($0.protocolConfiguration as? NETunnelProviderProtocol)?.providerBundleIdentifier == configuration.providerBundleIdentifier }) ?? NETunnelProviderManager()
+                let protocolConfiguration = NETunnelProviderProtocol()
+                protocolConfiguration.providerBundleIdentifier = configuration.providerBundleIdentifier
+                protocolConfiguration.providerConfiguration = configuration.options
+                protocolConfiguration.disconnectOnSleep = false
+
+                manager.localizedDescription = "BitChat Donor Tunnel"
+                manager.protocolConfiguration = protocolConfiguration
+                manager.isEnabled = true
+
+                manager.saveToPreferences { error in
+                    if let error {
+                        self.queue.async {
+                            self.state = .failed(error.localizedDescription)
+                            completion(.failure(error))
+                        }
+                        return
+                    }
+
+                    manager.loadFromPreferences { loadError in
+                        if let loadError {
+                            self.queue.async {
+                                self.state = .failed(loadError.localizedDescription)
+                                completion(.failure(loadError))
+                            }
+                            return
+                        }
+
+                        do {
+                            try manager.connection.startVPNTunnel(options: configuration.options)
+                            self.queue.async {
+                                self.manager = manager
+                                self.state = .active
+                                completion(.success(()))
+                            }
+                        } catch {
+                            self.queue.async {
+                                self.state = .failed(error.localizedDescription)
+                                completion(.failure(error))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func disable(completion: ((Result<Void, Error>) -> Void)? = nil) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            guard let manager = self.manager else {
+                completion?(.success(()))
+                self.state = .idle
+                return
+            }
+
+            self.state = .stopping
+            manager.connection.stopVPNTunnel()
+            manager.removeFromPreferences { error in
+                self.queue.async {
+                    if let error {
+                        self.state = .failed(error.localizedDescription)
+                        completion?(.failure(error))
+                    } else {
+                        self.manager = nil
+                        self.state = .idle
+                        completion?(.success(()))
+                    }
+                }
+            }
+        }
+    }
+
+    private func notifyStateChanged() {
+        NotificationCenter.default.post(name: .wifiDirectDonorStateChanged, object: self, userInfo: ["state": state])
+    }
+}
+@available(iOS 15.0, *)
+extension WiFiDirectDonorModeController.State {
+    var statusDescription: String {
+        switch self {
+        case .idle:
+            return NSLocalizedString("Donor mode is idle", comment: "Idle donor mode status")
+        case .preparing:
+            return NSLocalizedString("Preparing donor mode…", comment: "Preparing donor mode status")
+        case .active:
+            return NSLocalizedString("Donor mode active", comment: "Active donor mode status")
+        case .stopping:
+            return NSLocalizedString("Stopping donor mode…", comment: "Stopping donor mode status")
+        case .failed(let message):
+            return message
+        }
+    }
+}
+#endif

--- a/bitchat/Services/WiFiDirectMeshBridge.swift
+++ b/bitchat/Services/WiFiDirectMeshBridge.swift
@@ -9,7 +9,36 @@ import BitLogger
 /// relays them over peer-to-peer Wi-Fi. Incoming Wi-Fi frames are decoded back
 /// into `BitchatPacket`s and injected into the BLE pipeline so the rest of the
 /// application remains unaware of the transport swap.
+protocol WiFiDirectMeshBridgeDelegate: AnyObject {
+    func bridge(_ bridge: WiFiDirectMeshBridge, didReceiveResource resource: WiFiDirectMeshBridge.ResourceTransfer)
+    func bridge(_ bridge: WiFiDirectMeshBridge, didFailToSendResourceWith error: Error)
+}
+
 final class WiFiDirectMeshBridge: NSObject {
+    struct ResourceTransfer: Identifiable {
+        enum MediaType: String {
+            case generic
+            case image
+            case video
+        }
+
+        let id: UUID
+        let name: String
+        let url: URL
+        let mediaType: MediaType
+        let originatingPeerID: String
+
+        init(id: UUID = UUID(), name: String, url: URL, mediaType: MediaType, originatingPeerID: String) {
+            self.id = id
+            self.name = name
+            self.url = url
+            self.mediaType = mediaType
+            self.originatingPeerID = originatingPeerID
+        }
+    }
+
+    weak var delegate: WiFiDirectMeshBridgeDelegate?
+
     private weak var meshService: BLEService?
     private let workerQueue = DispatchQueue(label: "chat.bitchat.wifidirect")
     private let serviceType = "bchatmesh"
@@ -26,7 +55,9 @@ final class WiFiDirectMeshBridge: NSObject {
     // messageID -> (sources, lastSeen)
     private var inboundSources: [String: Set<String>] = [:]
     private var inboundTimestamps: [String: Date] = [:]
+    private var outboundResourcePendingPeers: [UUID: Int] = [:]
     private let inboundRetention: TimeInterval = 30
+    private var pendingResources: [UUID: (name: String, mediaType: ResourceTransfer.MediaType, origin: String)] = [:]
 
     init(meshService: BLEService) {
         self.meshService = meshService
@@ -44,6 +75,69 @@ final class WiFiDirectMeshBridge: NSObject {
             name: .meshServiceDidBroadcastPacket,
             object: meshService
         )
+    }
+
+    func sendResource(
+        at url: URL,
+        named name: String,
+        mediaType: ResourceTransfer.MediaType,
+        completion: ((Result<Void, Error>) -> Void)? = nil
+    ) {
+        workerQueue.async { [weak self] in
+            guard let self, let session = self.session else {
+                completion?(.failure(NSError(domain: "chat.bitchat.wifi", code: 9, userInfo: [NSLocalizedDescriptionKey: "session not ready"])))
+                return
+            }
+
+            let targets = session.connectedPeers
+            guard !targets.isEmpty else {
+                completion?(.failure(NSError(domain: "chat.bitchat.wifi", code: 10, userInfo: [NSLocalizedDescriptionKey: "no connected peers"])))
+                return
+            }
+
+            let transferID = UUID()
+            let resourceToken = "\(transferID.uuidString)::\(name)"
+            outboundResourcePendingPeers[transferID] = targets.count
+            for peer in targets {
+                session.sendResource(at: url, withName: resourceToken, toPeer: peer) { [weak self] error in
+                    guard let self else { return }
+                    self.workerQueue.async {
+                        if let error {
+                            let hadPending = self.outboundResourcePendingPeers.removeValue(forKey: transferID) != nil
+                            if hadPending {
+                                self.delegate?.bridge(self, didFailToSendResourceWith: error)
+                                completion?(.failure(error))
+                            }
+                        } else if var remaining = self.outboundResourcePendingPeers[transferID] {
+                            remaining -= 1
+                            if remaining <= 0 {
+                                self.outboundResourcePendingPeers.removeValue(forKey: transferID)
+                                completion?(.success(()))
+                            } else {
+                                self.outboundResourcePendingPeers[transferID] = remaining
+                            }
+                        }
+                    }
+                }
+            }
+
+            do {
+                let metadata = ResourceTransfer(id: transferID, name: name, url: url, mediaType: mediaType, originatingPeerID: meshService?.myPeerID ?? "")
+                let metadataData = try JSONEncoder().encode([
+                    "id": metadata.id.uuidString,
+                    "name": metadata.name,
+                    "type": metadata.mediaType.rawValue,
+                    "origin": metadata.originatingPeerID
+                ])
+                try session.send(metadataData, toPeers: targets, with: .reliable)
+            } catch {
+                let hadPending = outboundResourcePendingPeers.removeValue(forKey: transferID) != nil
+                if hadPending {
+                    delegate?.bridge(self, didFailToSendResourceWith: error)
+                }
+                completion?(.failure(error))
+            }
+        }
     }
 
     deinit {
@@ -164,6 +258,8 @@ final class WiFiDirectMeshBridge: NSObject {
         peerMeshIDs.removeAll()
         inboundSources.removeAll()
         inboundTimestamps.removeAll()
+        pendingResources.removeAll()
+        outboundResourcePendingPeers.removeAll()
     }
 
     private func pruneInboundCacheLocked(now: Date = Date()) {
@@ -236,6 +332,18 @@ extension WiFiDirectMeshBridge: MCSessionDelegate {
         workerQueue.async { [weak self] in
             guard let self, let meshService = self.meshService else { return }
             do {
+                if let metadata = try? JSONSerialization.jsonObject(with: data) as? [String: String],
+                   let idString = metadata["id"],
+                   let uuid = UUID(uuidString: idString),
+                   let name = metadata["name"],
+                   let typeRaw = metadata["type"],
+                   let mediaType = ResourceTransfer.MediaType(rawValue: typeRaw),
+                   let origin = metadata["origin"] {
+                    self.pendingResources[uuid] = (name: name, mediaType: mediaType, origin: origin)
+                    self.peerMeshIDs[peerID] = origin
+                    return
+                }
+
                 let envelope = try Self.decodeEnvelope(data)
                 self.peerMeshIDs[peerID] = envelope.peerID
                 guard let packet = BitchatPacket.from(envelope.payload) else { return }
@@ -254,7 +362,41 @@ extension WiFiDirectMeshBridge: MCSessionDelegate {
 
     func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, with progress: Progress) {}
 
-    func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, at localURL: URL?, withError error: Error?) {}
+    func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, at localURL: URL?, withError error: Error?) {
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            guard error == nil, let localURL else {
+                if let error {
+                    self.delegate?.bridge(self, didFailToSendResourceWith: error)
+                }
+                return
+            }
+
+            let destinationDir = FileManager.default.temporaryDirectory.appendingPathComponent("WiFiDirect", isDirectory: true)
+            try? FileManager.default.createDirectory(at: destinationDir, withIntermediateDirectories: true)
+            let components = resourceName.split(separator: "::", maxSplits: 1, omittingEmptySubsequences: false)
+            let idComponent = components.first.flatMap { UUID(uuidString: String($0)) }
+            let finalName = components.count > 1 ? String(components[1]) : resourceName
+            let destinationURL = destinationDir.appendingPathComponent(finalName)
+            try? FileManager.default.removeItem(at: destinationURL)
+            do {
+                try FileManager.default.copyItem(at: localURL, to: destinationURL)
+                let meshID = self.peerMeshIDs[peerID] ?? peerID.displayName
+                let transfer: ResourceTransfer
+                if
+                    let idComponent,
+                    let metadata = self.pendingResources.removeValue(forKey: idComponent)
+                {
+                    transfer = ResourceTransfer(id: idComponent, name: metadata.name, url: destinationURL, mediaType: metadata.mediaType, originatingPeerID: metadata.origin)
+                } else {
+                    transfer = ResourceTransfer(name: finalName, url: destinationURL, mediaType: .generic, originatingPeerID: meshID)
+                }
+                self.delegate?.bridge(self, didReceiveResource: transfer)
+            } catch {
+                self.delegate?.bridge(self, didFailToSendResourceWith: error)
+            }
+        }
+    }
 
     func session(_ session: MCSession, didReceive certificate: [Any]?, fromPeer peerID: MCPeerID, certificateHandler: @escaping (Bool) -> Void) {
         certificateHandler(true)

--- a/bitchat/ViewModels/ChatViewModel.swift
+++ b/bitchat/ViewModels/ChatViewModel.swift
@@ -347,6 +347,8 @@ final class ChatViewModel: ObservableObject, BitchatDelegate {
     let meshService: Transport
 #if os(iOS)
     private var wifiDirectBridge: WiFiDirectMeshBridge?
+    @available(iOS 15.0, *)
+    private var wifiDirectDonorController: WiFiDirectDonorModeController?
 #endif
     let identityManager: SecureIdentityStateManagerProtocol
     
@@ -399,6 +401,11 @@ final class ChatViewModel: ObservableObject, BitchatDelegate {
     @Published var showBluetoothAlert = false
     @Published var bluetoothAlertMessage = ""
     @Published var bluetoothState: CBManagerState = .unknown
+#if os(iOS)
+    @Published var wifiDirectInboundTransfers: [WiFiDirectMeshBridge.ResourceTransfer] = []
+    @Published var wifiDirectBridgeError: String?
+    @Published var donorModeStatusDescription: String = ""
+#endif
 
     // Presentation state for privacy gating
     @Published var isLocationChannelsSheetPresented: Bool = false
@@ -502,7 +509,19 @@ final class ChatViewModel: ObservableObject, BitchatDelegate {
         self.meshService = BLEService(keychain: keychain, identityManager: identityManager)
 #if os(iOS)
         if let bleTransport = self.meshService as? BLEService {
-            self.wifiDirectBridge = WiFiDirectMeshBridge(meshService: bleTransport)
+            let bridge = WiFiDirectMeshBridge(meshService: bleTransport)
+            bridge.delegate = self
+            self.wifiDirectBridge = bridge
+        }
+        if #available(iOS 15.0, *) {
+            let controller = WiFiDirectDonorModeController()
+            self.wifiDirectDonorController = controller
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleDonorModeState(_:)),
+                name: .wifiDirectDonorStateChanged,
+                object: controller
+            )
         }
 #endif
 
@@ -858,10 +877,75 @@ final class ChatViewModel: ObservableObject, BitchatDelegate {
     }
     
     // MARK: - Deinitialization
-    
+
     deinit {
         // No need to force UserDefaults synchronization
+#if os(iOS)
+        NotificationCenter.default.removeObserver(self, name: .wifiDirectDonorStateChanged, object: nil)
+#endif
     }
+
+#if os(iOS)
+    func sendWiFiDirectResource(at url: URL, name: String, mediaType: WiFiDirectMeshBridge.ResourceTransfer.MediaType) {
+        wifiDirectBridge?.sendResource(at: url, named: name, mediaType: mediaType) { [weak self] result in
+            guard let self else { return }
+            if case let .failure(error) = result {
+                DispatchQueue.main.async {
+                    self.wifiDirectBridgeError = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    func enableDonorMode(providerBundleIdentifier: String, options: [String: NSObject] = [:]) {
+        guard #available(iOS 15.0, *), let controller = wifiDirectDonorController else {
+            donorModeStatusDescription = NSLocalizedString("Wi‑Fi Direct donor mode requires iOS 15 or later.", comment: "Donor mode unsupported message")
+            return
+        }
+
+        donorModeStatusDescription = NSLocalizedString("Preparing donor mode…", comment: "Donor mode preparing status")
+        let configuration = WiFiDirectDonorModeController.Configuration(providerBundleIdentifier: providerBundleIdentifier, options: options)
+        controller.enable(with: configuration) { [weak self] result in
+            guard let self else { return }
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    self.donorModeStatusDescription = controller.state.statusDescription
+                case .failure(let error):
+                    self.donorModeStatusDescription = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    func disableDonorMode() {
+        guard #available(iOS 15.0, *), let controller = wifiDirectDonorController else {
+            donorModeStatusDescription = NSLocalizedString("Wi‑Fi Direct donor mode requires iOS 15 or later.", comment: "Donor mode unsupported message")
+            return
+        }
+
+        donorModeStatusDescription = NSLocalizedString("Stopping donor mode…", comment: "Donor mode stopping status")
+        controller.disable { [weak self] result in
+            guard let self else { return }
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    self.donorModeStatusDescription = controller.state.statusDescription
+                case .failure(let error):
+                    self.donorModeStatusDescription = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    @objc private func handleDonorModeState(_ notification: Notification) {
+        guard #available(iOS 15.0, *),
+              let state = notification.userInfo?["state"] as? WiFiDirectDonorModeController.State else { return }
+        DispatchQueue.main.async {
+            self.donorModeStatusDescription = state.statusDescription
+        }
+    }
+#endif
 
     // MARK: - Tor notifications
     @objc private func handleTorWillStart() {
@@ -6285,3 +6369,19 @@ private func checkForMentions(_ message: BitchatMessage) {
     }
 }
 // End of ChatViewModel class
+
+#if os(iOS)
+extension ChatViewModel: WiFiDirectMeshBridgeDelegate {
+    func bridge(_ bridge: WiFiDirectMeshBridge, didReceiveResource resource: WiFiDirectMeshBridge.ResourceTransfer) {
+        DispatchQueue.main.async {
+            self.wifiDirectInboundTransfers.append(resource)
+        }
+    }
+
+    func bridge(_ bridge: WiFiDirectMeshBridge, didFailToSendResourceWith error: Error) {
+        DispatchQueue.main.async {
+            self.wifiDirectBridgeError = error.localizedDescription
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- extend the Wi-Fi Direct mesh bridge with a delegate, attachment transfer support, and inbound caching clean up
- add a donor mode controller that prepares an NEPacketTunnel-based sharing session and emits lifecycle notifications
- expose Wi-Fi Direct resource handling and donor mode controls from the chat view model, along with donor status notifications

## Testing
- `swift build` *(fails: localPackages/BitLogger/Sources/OSLog+Categories.swift:9:8: error: no such module 'os.log')*


------
https://chatgpt.com/codex/tasks/task_e_68dc1630967c8332b98287b8137d1ac1