### PR TITLE
Implement Wi-Fi Direct donor packet tunnel

### DIFF
--- a/DonorTunnelProvider/DonorTunnelConfiguration.swift
+++ b/DonorTunnelProvider/DonorTunnelConfiguration.swift
@@ -1,0 +1,121 @@
+#if os(iOS)
+import Foundation
+import Network
+import NetworkExtension
+
+struct DonorTunnelConfiguration {
+    struct Keys {
+        static let donorHost = "donor_host"
+        static let donorPort = "donor_port"
+        static let tunnelIPv4Address = "tunnel_ipv4_address"
+        static let tunnelIPv4SubnetMask = "tunnel_ipv4_subnet_mask"
+        static let remoteIPv4Gateway = "remote_ipv4_gateway"
+        static let tunnelIPv6Address = "tunnel_ipv6_address"
+        static let tunnelIPv6PrefixLength = "tunnel_ipv6_prefix_length"
+        static let dnsServers = "dns_servers"
+        static let mtu = "mtu"
+        static let keepAliveInterval = "keep_alive_interval"
+        static let handshakeMetadata = "handshake_metadata"
+        static let routeAllTraffic = "route_all_traffic"
+    }
+
+    let donorHost: NWEndpoint.Host
+    let donorPort: NWEndpoint.Port
+    let remoteAddress: String
+    let ipv4Address: String
+    let ipv4SubnetMask: String
+    let shouldRouteAllTraffic: Bool
+    let dnsServers: [String]
+    let mtu: Int?
+    let keepAliveInterval: TimeInterval?
+    let handshakeMetadata: Data?
+    let ipv6Address: String?
+    let ipv6PrefixLength: Int?
+    let startupOptions: [String: Any]?
+
+    init(providerConfiguration: [String: Any]?, startupOptions: [String: Any]?) throws {
+        guard let providerConfiguration else {
+            throw DonorTunnelError.invalidConfiguration("Missing provider configuration")
+        }
+
+        guard let hostString = providerConfiguration[Keys.donorHost] as? String, !hostString.isEmpty else {
+            throw DonorTunnelError.invalidConfiguration("Donor host is missing")
+        }
+        guard let portValue = (providerConfiguration[Keys.donorPort] as? NSNumber)?.uint16Value,
+              let port = NWEndpoint.Port(rawValue: portValue) else {
+            throw DonorTunnelError.invalidConfiguration("Donor port is missing or invalid")
+        }
+
+        let ipv4Address = (providerConfiguration[Keys.tunnelIPv4Address] as? String) ?? "10.242.0.2"
+        let ipv4Mask = (providerConfiguration[Keys.tunnelIPv4SubnetMask] as? String) ?? "255.255.255.0"
+        let remoteAddress = (providerConfiguration[Keys.remoteIPv4Gateway] as? String) ?? hostString
+        let dnsServers = providerConfiguration[Keys.dnsServers] as? [String] ?? []
+        let mtu = (providerConfiguration[Keys.mtu] as? NSNumber)?.intValue
+        let keepAliveInterval = (providerConfiguration[Keys.keepAliveInterval] as? NSNumber)?.doubleValue
+        let handshakeMetadata = providerConfiguration[Keys.handshakeMetadata] as? Data
+        let ipv6Address = providerConfiguration[Keys.tunnelIPv6Address] as? String
+        let ipv6PrefixLength = (providerConfiguration[Keys.tunnelIPv6PrefixLength] as? NSNumber)?.intValue
+        let routeAll = (providerConfiguration[Keys.routeAllTraffic] as? NSNumber)?.boolValue ?? true
+
+        self.donorHost = NWEndpoint.Host(hostString)
+        self.donorPort = port
+        self.remoteAddress = remoteAddress
+        self.ipv4Address = ipv4Address
+        self.ipv4SubnetMask = ipv4Mask
+        self.dnsServers = dnsServers
+        self.mtu = mtu
+        self.keepAliveInterval = keepAliveInterval
+        self.handshakeMetadata = handshakeMetadata
+        self.ipv6Address = ipv6Address
+        self.ipv6PrefixLength = ipv6PrefixLength
+        self.shouldRouteAllTraffic = routeAll
+        self.startupOptions = startupOptions
+    }
+
+    func makeNetworkSettings() -> NEPacketTunnelNetworkSettings {
+        let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: remoteAddress)
+
+        let ipv4Settings = NEIPv4Settings(addresses: [ipv4Address], subnetMasks: [ipv4SubnetMask])
+        if shouldRouteAllTraffic {
+            ipv4Settings.includedRoutes = [NEIPv4Route.default()]
+        }
+        settings.ipv4Settings = ipv4Settings
+
+        if let ipv6Address, let prefix = ipv6PrefixLength {
+            let ipv6Settings = NEIPv6Settings(addresses: [ipv6Address], networkPrefixLengths: [NSNumber(value: prefix)])
+            if shouldRouteAllTraffic {
+                ipv6Settings.includedRoutes = [NEIPv6Route.default()]
+            }
+            settings.ipv6Settings = ipv6Settings
+        }
+
+        if !dnsServers.isEmpty {
+            let dnsSettings = NEDNSSettings(servers: dnsServers)
+            dnsSettings.matchDomains = [""]
+            settings.dnsSettings = dnsSettings
+        }
+
+        if let mtu {
+            settings.mtu = NSNumber(value: mtu)
+        }
+
+        return settings
+    }
+}
+
+enum DonorTunnelError: Error {
+    case invalidConfiguration(String)
+    case connectionFailed(String)
+}
+
+extension DonorTunnelError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration(let message):
+            return message
+        case .connectionFailed(let message):
+            return message
+        }
+    }
+}
+#endif

--- a/DonorTunnelProvider/Info.plist
+++ b/DonorTunnelProvider/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionAttributes</key>
+        <dict>
+            <key>NEProviderSupportedNetworkTypes</key>
+            <array>
+                <string>VPN</string>
+            </array>
+        </dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.networkextension.packet-tunnel</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).PacketTunnelProvider</string>
+    </dict>
+</dict>
+</plist>

--- a/DonorTunnelProvider/PacketTunnelProvider.swift
+++ b/DonorTunnelProvider/PacketTunnelProvider.swift
@@ -1,0 +1,346 @@
+#if os(iOS)
+import Darwin
+import Foundation
+import Network
+import NetworkExtension
+import os.log
+
+final class PacketTunnelProvider: NEPacketTunnelProvider {
+    private enum FrameType: UInt8 {
+        case packet = 0x01
+        case handshake = 0x02
+        case keepAlive = 0x03
+        case acknowledgment = 0x04
+        case error = 0x05
+    }
+
+    private let logger = Logger(subsystem: "chat.bitchat.donor", category: "tunnel")
+    private let workerQueue = DispatchQueue(label: "chat.bitchat.donor.tunnel")
+    private var connection: NWConnection?
+    private var configuration: DonorTunnelConfiguration?
+    private var startCompletion: ((Error?) -> Void)?
+    private var receiveBuffer = Data()
+    private var keepAliveTimer: DispatchSourceTimer?
+
+    override func startTunnel(options: [String: NSObject]?, completionHandler: @escaping (Error?) -> Void) {
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            do {
+                let startupOptions = Self.normalize(options: options)
+                let providerProtocol = self.protocolConfiguration as? NETunnelProviderProtocol
+                let configuration = try DonorTunnelConfiguration(
+                    providerConfiguration: providerProtocol?.providerConfiguration,
+                    startupOptions: startupOptions
+                )
+
+                self.configuration = configuration
+                self.startCompletion = completionHandler
+
+                self.logger.log("Configuring tunnel for host \(configuration.donorHost, privacy: .public):\(configuration.donorPort)")
+                let networkSettings = configuration.makeNetworkSettings()
+                self.setTunnelNetworkSettings(networkSettings) { [weak self] error in
+                    guard let self else { return }
+                    if let error {
+                        self.logger.error("Failed to apply tunnel network settings: \(error.localizedDescription, privacy: .public)")
+                        self.finishStart(with: error)
+                        return
+                    }
+                    self.establishConnection()
+                }
+            } catch {
+                self.logger.error("Invalid donor configuration: \(error.localizedDescription, privacy: .public)")
+                completionHandler(error)
+            }
+        }
+    }
+
+    override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
+        workerQueue.async { [weak self] in
+            guard let self else {
+                completionHandler()
+                return
+            }
+
+            self.logger.log("Stopping donor tunnel: reason=\(reason.rawValue)")
+            self.startCompletion = nil
+            self.keepAliveTimer?.cancel()
+            self.keepAliveTimer = nil
+            self.connection?.cancel()
+            self.connection = nil
+            self.configuration = nil
+            self.receiveBuffer.removeAll(keepingCapacity: false)
+            completionHandler()
+        }
+    }
+
+    override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)? = nil) {
+        workerQueue.async { [weak self] in
+            guard let self else {
+                completionHandler?(nil)
+                return
+            }
+
+            guard let configuration = self.configuration else {
+                completionHandler?(nil)
+                return
+            }
+
+            self.logger.log("Received app message with \(messageData.count) bytes")
+            // Forward messages from the host app to the donor as out-of-band
+            // control signals.  These are framed as handshake packets so the
+            // donor can treat them as metadata updates.
+            self.sendFrame(type: .handshake, payload: messageData)
+            if configuration.keepAliveInterval != nil {
+                self.resetKeepAliveTimer()
+            }
+            completionHandler?(Data())
+        }
+    }
+
+    // MARK: - Connection lifecycle
+
+    private func establishConnection() {
+        guard let configuration else {
+            finishStart(with: DonorTunnelError.invalidConfiguration("Missing donor configuration"))
+            return
+        }
+
+        let parameters = NWParameters.tcp
+        parameters.allowLocalEndpointReuse = true
+        parameters.prohibitConstrainedPaths = false
+
+        let connection = NWConnection(host: configuration.donorHost, port: configuration.donorPort, using: parameters)
+        connection.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            self.workerQueue.async {
+                switch state {
+                case .ready:
+                    self.logger.log("Donor connection ready")
+                    self.startPacketForwarding()
+                    self.scheduleReceive()
+                    self.sendInitialHandshake()
+                    self.startKeepAliveTimerIfNeeded()
+                    self.finishStart(with: nil)
+                case .failed(let error):
+                    self.logger.error("Donor connection failed: \(error.localizedDescription, privacy: .public)")
+                    self.handleConnectionFailure(error)
+                case .waiting(let error):
+                    self.logger.warning("Donor connection waiting: \(String(describing: error), privacy: .public)")
+                case .cancelled:
+                    self.logger.log("Donor connection cancelled")
+                    self.handleConnectionFailure(nil)
+                default:
+                    break
+                }
+            }
+        }
+
+        self.connection = connection
+        connection.start(queue: workerQueue)
+    }
+
+    private func handleConnectionFailure(_ error: Error?) {
+        if let startCompletion {
+            self.startCompletion = nil
+            startCompletion(error ?? DonorTunnelError.connectionFailed("Unable to connect to donor"))
+            return
+        }
+
+        let nsError: NSError
+        if let error = error as NSError? {
+            nsError = error
+        } else {
+            nsError = NSError(domain: "chat.bitchat.donor", code: -1, userInfo: [NSLocalizedDescriptionKey: "Donor connection closed"])
+        }
+        cancelTunnelWithError(nsError)
+    }
+
+    private func finishStart(with error: Error?) {
+        if let completion = startCompletion {
+            startCompletion = nil
+            completion(error)
+        } else if let error {
+            cancelTunnelWithError(error)
+        }
+    }
+
+    // MARK: - Packet forwarding
+
+    private func startPacketForwarding() {
+        packetFlow.readPackets { [weak self] packets, _ in
+            guard let self else { return }
+            if packets.isEmpty {
+                self.startPacketForwarding()
+                return
+            }
+
+            self.workerQueue.async {
+                for packet in packets {
+                    self.sendPacket(packet)
+                }
+            }
+
+            self.startPacketForwarding()
+        }
+    }
+
+    private func sendPacket(_ packet: Data) {
+        guard let connection else { return }
+        var payload = Data(capacity: packet.count)
+        payload.append(packet)
+        sendFrame(type: .packet, payload: payload, on: connection)
+    }
+
+    private func scheduleReceive() {
+        guard let connection else { return }
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65535) { [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            self.workerQueue.async {
+                if let data, !data.isEmpty {
+                    self.receiveBuffer.append(data)
+                    self.processInboundBuffer()
+                }
+
+                if let error {
+                    self.logger.error("Receive error: \(error.localizedDescription, privacy: .public)")
+                    self.handleConnectionFailure(error)
+                    return
+                }
+
+                if isComplete {
+                    self.logger.log("Donor connection signalled completion")
+                    self.handleConnectionFailure(nil)
+                    return
+                }
+
+                self.scheduleReceive()
+            }
+        }
+    }
+
+    private func processInboundBuffer() {
+        while receiveBuffer.count >= 5 {
+            let lengthData = receiveBuffer.prefix(4)
+            let payloadLength = lengthData.withUnsafeBytes { $0.load(as: UInt32.self).bigEndian }
+            let totalLength = Int(payloadLength) + 4
+            guard receiveBuffer.count >= totalLength else { return }
+
+            let frameData = receiveBuffer.subdata(in: 4..<totalLength)
+            receiveBuffer.removeSubrange(0..<totalLength)
+
+            guard let frameTypeRaw = frameData.first,
+                  let frameType = FrameType(rawValue: frameTypeRaw) else {
+                logger.error("Received frame with unknown type")
+                continue
+            }
+
+            let payload = frameData.dropFirst()
+            switch frameType {
+            case .packet:
+                deliverPacket(Data(payload))
+            case .handshake:
+                logger.log("Received donor handshake update of \(payload.count) bytes")
+            case .keepAlive:
+                logger.log("Received keep alive from donor")
+                resetKeepAliveTimer()
+            case .acknowledgment:
+                logger.log("Received acknowledgment from donor")
+            case .error:
+                let message = String(data: payload, encoding: .utf8) ?? "Unknown error"
+                logger.error("Donor reported error: \(message, privacy: .public)")
+            }
+        }
+    }
+
+    private func deliverPacket(_ packet: Data) {
+        guard !packet.isEmpty else { return }
+        let protocolNumber: NSNumber
+        if let firstByte = packet.first {
+            let version = (firstByte & 0xF0) >> 4
+            if version == 6 {
+                protocolNumber = NSNumber(value: AF_INET6)
+            } else {
+                protocolNumber = NSNumber(value: AF_INET)
+            }
+        } else {
+            protocolNumber = NSNumber(value: AF_INET)
+        }
+
+        packetFlow.writePackets([packet], withProtocols: [protocolNumber])
+    }
+
+    private func sendInitialHandshake() {
+        guard let configuration else { return }
+        var handshakePayload: [String: Any] = [:]
+        if let metadata = configuration.handshakeMetadata {
+            if let json = try? JSONSerialization.jsonObject(with: metadata, options: []) {
+                handshakePayload["metadata"] = json
+            }
+        }
+        if let startup = configuration.startupOptions, !startup.isEmpty {
+            handshakePayload["startup_options"] = startup
+        }
+
+        guard !handshakePayload.isEmpty,
+              let data = try? JSONSerialization.data(withJSONObject: handshakePayload, options: []) else {
+            return
+        }
+
+        sendFrame(type: .handshake, payload: data)
+    }
+
+    private func startKeepAliveTimerIfNeeded() {
+        guard let interval = configuration?.keepAliveInterval, interval > 0 else { return }
+        let timer = DispatchSource.makeTimerSource(queue: workerQueue)
+        timer.schedule(deadline: .now() + interval, repeating: interval)
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            self.sendFrame(type: .keepAlive, payload: Data())
+        }
+        timer.resume()
+        keepAliveTimer = timer
+    }
+
+    private func resetKeepAliveTimer() {
+        guard let interval = configuration?.keepAliveInterval, interval > 0 else { return }
+        keepAliveTimer?.schedule(deadline: .now() + interval, repeating: interval)
+    }
+
+    private func sendFrame(type: FrameType, payload: Data, on connection: NWConnection? = nil) {
+        guard let connection = connection ?? self.connection else { return }
+        var frame = Data()
+        var length = UInt32(payload.count + 1).bigEndian
+        frame.append(Data(bytes: &length, count: MemoryLayout<UInt32>.size))
+        frame.append(type.rawValue)
+        frame.append(payload)
+
+        connection.send(content: frame, completion: .contentProcessed { [weak self] error in
+            if let error {
+                self?.logger.error("Failed to send frame: \(error.localizedDescription, privacy: .public)")
+                self?.handleConnectionFailure(error)
+            }
+        })
+    }
+
+    // MARK: - Helpers
+
+    private static func normalize(options: [String: NSObject]?) -> [String: Any]? {
+        guard let options else { return nil }
+        var normalized: [String: Any] = [:]
+        for (key, value) in options {
+            if let string = value as? String {
+                normalized[key] = string
+            } else if let number = value as? NSNumber {
+                normalized[key] = number
+            } else if let data = value as? Data {
+                normalized[key] = data.base64EncodedString()
+            } else if let array = value as? [Any] {
+                normalized[key] = array
+            } else if let dict = value as? [String: Any] {
+                normalized[key] = dict
+            }
+        }
+        return normalized.isEmpty ? nil : normalized
+    }
+}
+#endif

--- a/bitchat/Services/WiFiDirectDonorModeController.swift
+++ b/bitchat/Services/WiFiDirectDonorModeController.swift
@@ -14,11 +14,14 @@ final class WiFiDirectDonorModeController {
         /// The bundle identifier of the `NEPacketTunnelProvider` extension that
         /// performs actual packet forwarding. This must be declared in the host app.
         let providerBundleIdentifier: String
+        /// Optional human-readable server address exposed to the system VPN UI.
+        let serverAddress: String?
         /// Optional metadata propagated to the provider during startup.
         let options: [String: NSObject]
 
-        init(providerBundleIdentifier: String, options: [String: NSObject] = [:]) {
+        init(providerBundleIdentifier: String, serverAddress: String? = nil, options: [String: NSObject] = [:]) {
             self.providerBundleIdentifier = providerBundleIdentifier
+            self.serverAddress = serverAddress
             self.options = options
         }
     }
@@ -64,6 +67,7 @@ final class WiFiDirectDonorModeController {
                 let protocolConfiguration = NETunnelProviderProtocol()
                 protocolConfiguration.providerBundleIdentifier = configuration.providerBundleIdentifier
                 protocolConfiguration.providerConfiguration = configuration.options
+                protocolConfiguration.serverAddress = configuration.serverAddress
                 protocolConfiguration.disconnectOnSleep = false
 
                 manager.localizedDescription = "BitChat Donor Tunnel"

--- a/bitchat/Services/WiFiDirectDonorModeOptions.swift
+++ b/bitchat/Services/WiFiDirectDonorModeOptions.swift
@@ -1,0 +1,116 @@
+#if os(iOS)
+import Foundation
+
+/// Strongly typed helper for constructing the provider configuration passed to
+/// ``WiFiDirectDonorModeController``.  The options produced here are consumed
+/// by the `NEPacketTunnelProvider` shipped with the donor mode extension.  By
+/// keeping the keys in one place we avoid fragile stringly‑typed configuration
+/// throughout the application.
+struct WiFiDirectDonorModeOptions {
+    enum OptionKey {
+        static let donorHost = "donor_host"
+        static let donorPort = "donor_port"
+        static let tunnelIPv4Address = "tunnel_ipv4_address"
+        static let tunnelIPv4SubnetMask = "tunnel_ipv4_subnet_mask"
+        static let remoteIPv4Gateway = "remote_ipv4_gateway"
+        static let tunnelIPv6Address = "tunnel_ipv6_address"
+        static let tunnelIPv6PrefixLength = "tunnel_ipv6_prefix_length"
+        static let dnsServers = "dns_servers"
+        static let mtu = "mtu"
+        static let keepAliveInterval = "keep_alive_interval"
+        static let handshakeMetadata = "handshake_metadata"
+        static let routeAllTraffic = "route_all_traffic"
+    }
+
+    /// The IP or hostname of the donor relay reachable over Wi‑Fi Direct.
+    let donorHost: String
+    /// The TCP port exposed by the donor relay.
+    let donorPort: UInt16
+    /// The IPv4 address assigned to the local tunnel interface.
+    let tunnelIPv4Address: String
+    /// The IPv4 subnet mask for the local tunnel interface.
+    let tunnelIPv4SubnetMask: String
+    /// Optional explicit gateway for the remote tunnel endpoint.  Defaults to
+    /// ``donorHost`` when omitted.
+    let remoteIPv4Gateway: String?
+    /// Optional IPv6 address for the tunnel interface.
+    let tunnelIPv6Address: String?
+    /// Optional IPv6 prefix length for the tunnel interface.
+    let tunnelIPv6PrefixLength: Int?
+    /// DNS resolvers advertised to the system while the tunnel is active.
+    let dnsServers: [String]
+    /// Custom MTU to apply to the tunnel.
+    let mtu: Int?
+    /// Interval (in seconds) between keep alive frames sent to the donor.
+    let keepAliveInterval: TimeInterval?
+    /// Arbitrary metadata forwarded to the donor during the handshake.
+    let handshakeMetadata: [String: String]
+    /// Whether the tunnel should install a default route that captures all
+    /// device traffic.
+    let routeAllTraffic: Bool
+
+    init(
+        donorHost: String,
+        donorPort: UInt16,
+        tunnelIPv4Address: String = "10.242.0.2",
+        tunnelIPv4SubnetMask: String = "255.255.255.0",
+        remoteIPv4Gateway: String? = nil,
+        tunnelIPv6Address: String? = nil,
+        tunnelIPv6PrefixLength: Int? = nil,
+        dnsServers: [String] = ["1.1.1.1", "9.9.9.9"],
+        mtu: Int? = 1380,
+        keepAliveInterval: TimeInterval? = 30,
+        handshakeMetadata: [String: String] = [:],
+        routeAllTraffic: Bool = true
+    ) {
+        self.donorHost = donorHost
+        self.donorPort = donorPort
+        self.tunnelIPv4Address = tunnelIPv4Address
+        self.tunnelIPv4SubnetMask = tunnelIPv4SubnetMask
+        self.remoteIPv4Gateway = remoteIPv4Gateway
+        self.tunnelIPv6Address = tunnelIPv6Address
+        self.tunnelIPv6PrefixLength = tunnelIPv6PrefixLength
+        self.dnsServers = dnsServers
+        self.mtu = mtu
+        self.keepAliveInterval = keepAliveInterval
+        self.handshakeMetadata = handshakeMetadata
+        self.routeAllTraffic = routeAllTraffic
+    }
+
+    /// Converts the strongly typed representation into the dictionary expected
+    /// by `NEPacketTunnelProvider`.  All values are coerced into property list
+    /// compatible types to satisfy the NetworkExtension requirements.
+    func asProviderConfiguration() throws -> [String: NSObject] {
+        var configuration: [String: NSObject] = [
+            OptionKey.donorHost: donorHost as NSString,
+            OptionKey.donorPort: NSNumber(value: donorPort),
+            OptionKey.tunnelIPv4Address: tunnelIPv4Address as NSString,
+            OptionKey.tunnelIPv4SubnetMask: tunnelIPv4SubnetMask as NSString,
+            OptionKey.routeAllTraffic: NSNumber(value: routeAllTraffic)
+        ]
+
+        if let remoteIPv4Gateway {
+            configuration[OptionKey.remoteIPv4Gateway] = remoteIPv4Gateway as NSString
+        }
+        if let tunnelIPv6Address, let tunnelIPv6PrefixLength {
+            configuration[OptionKey.tunnelIPv6Address] = tunnelIPv6Address as NSString
+            configuration[OptionKey.tunnelIPv6PrefixLength] = NSNumber(value: tunnelIPv6PrefixLength)
+        }
+        if !dnsServers.isEmpty {
+            configuration[OptionKey.dnsServers] = dnsServers as NSArray
+        }
+        if let mtu {
+            configuration[OptionKey.mtu] = NSNumber(value: mtu)
+        }
+        if let keepAliveInterval {
+            configuration[OptionKey.keepAliveInterval] = NSNumber(value: keepAliveInterval)
+        }
+        if !handshakeMetadata.isEmpty {
+            let json = try JSONSerialization.data(withJSONObject: handshakeMetadata, options: [])
+            configuration[OptionKey.handshakeMetadata] = json as NSData
+        }
+
+        return configuration
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add a strongly-typed helper for building Wi-Fi Direct donor mode provider options
- extend the donor mode controller so the configured tunnel exposes a server address
- implement the packet-tunnel network extension that forwards packets to the donor over a framed TCP link and add its Info.plist

## Testing
- not run (iOS-specific components)

------
https://chatgpt.com/codex/tasks/task_e_68dc1eccfb088332924047d0a957d9f5